### PR TITLE
Implement initial support for toggling view transform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JERI Viewer
 
-The JavaScript Extended-Range Image (JERI) Viewer was designed to be an easy-to-use, interactive component that can be embedded in websites and web-based documents. It contains a version of OpenEXR that was transpiled with [emscripten](http://kripken.github.io/emscripten-site/index.html) from C++ to JavaScript to enable running it in a web browser. Around this core, JERI offers multi-level tabs that allow easy navigation through large sets of images and supports zooming, panning, changing exposure, and quickly toggling between images. These features are built using [React](https://reactjs.org/), but knowledge of this framework is not required to use the viewer. 
+The JavaScript Extended-Range Image (JERI) Viewer was designed to be an easy-to-use, interactive component that can be embedded in websites and web-based documents. It contains a version of OpenEXR that was transpiled with [emscripten](http://kripken.github.io/emscripten-site/index.html) from C++ to JavaScript to enable running it in a web browser. Around this core, JERI offers multi-level tabs that allow easy navigation through large sets of images and supports zooming, panning, changing exposure and view transform, and quickly toggling between images. These features are built using [React](https://reactjs.org/), but knowledge of this framework is not required to use the viewer.
 
 See [jeri.io](https://jeri.io/) for a live demonstration.
 

--- a/src/components/ImageFrame.tsx
+++ b/src/components/ImageFrame.tsx
@@ -23,6 +23,7 @@ const StretchingDiv = styled.div`
 
 export interface ImageFrameProps {
     image: ImageInput;
+    viewTransform: number;
     exposure: number;
     gamma: number;
     offset: number;
@@ -119,10 +120,12 @@ export default class ImageFrame extends React.Component<ImageFrameProps, {}> {
 
   private updateCanvasProps(previousProps: ImageFrameProps | null = null) {
     if (!previousProps ||
+        previousProps.viewTransform !== this.props.viewTransform ||
         previousProps.exposure !== this.props.exposure ||
         previousProps.gamma !== this.props.gamma ||
         previousProps.offset !== this.props.offset) {
       this.imageLayer.setTonemapping({
+        viewTransform: this.props.viewTransform,
         exposure: this.props.exposure,
         offset: this.props.offset,
         gamma: this.props.gamma

--- a/src/components/ImageFrameWithLoading.tsx
+++ b/src/components/ImageFrameWithLoading.tsx
@@ -43,6 +43,7 @@ export type ImageSpec = ImageSpecUrl | ImageSpecLossMap;
 
 export interface ImageFrameWithLoadingProps {
   imageSpec: ImageSpec;
+  viewTransform: number;
   exposure: number;
   gamma: number;
   offset: number;
@@ -101,6 +102,7 @@ export default class ImageFrameWithLoading extends
       <StretchingDiv>
       {this.state.image != null ?
         <ImageFrame
+          viewTransform={this.props.viewTransform}
           exposure={this.props.exposure}
           gamma={this.props.gamma}
           offset={this.props.offset}

--- a/src/components/ImageViewer/HelpScreen.tsx
+++ b/src/components/ImageViewer/HelpScreen.tsx
@@ -53,7 +53,7 @@ export default () => {
           </tr>
           <tr>
             <th>Shift + click</th>
-            <td>Open a tab, and activate keyboard shortcuts for the row clicked.</td>
+            <td>Open a tab, and activate keyboard shortcuts for the row clicked</td>
           </tr>
           <tr>
             <th>e / E</th>
@@ -62,6 +62,10 @@ export default () => {
           <tr>
             <th>r</th>
             <td>Reset exposure, positioning and zooming</td>
+          </tr>
+          <tr>
+            <th>t</th>
+            <td>Toggle between the Gamma 2.2 and the Pseudo ARRI K1S1 view transforms</td>
           </tr>
           <tr>
             <th>f</th>

--- a/src/layers/ImageLayer.ts
+++ b/src/layers/ImageLayer.ts
@@ -9,6 +9,12 @@ enum DrawMode {
   ColorMap = 2,
 }
 
+enum ViewTransform {
+  None = -1,
+  Gamma22 = 0,
+  K1S1 = 1,
+}
+
 const vertexShaderSource = `
 attribute vec3 aVertexPosition;
 attribute vec2 aTextureCoord;
@@ -21,6 +27,7 @@ void main(void) {
 
 const fragmentShaderSource = `
 precision mediump float;
+uniform int viewTransform;
 uniform float exposure;
 uniform float offset;
 uniform float gamma;
@@ -41,13 +48,52 @@ vec3 lookupOffset(sampler2D sampler, vec2 position, vec2 offset) {
     return texture2D(sampler, position + offset / imageSize).rgb;
 }
 
+float log10(float a) {
+  const float logBase10 = 1.0 / log2( 10.0 );
+
+  return log2(a) * logBase10;
+}
+
 float luminance(vec3 rgb) {
   return dot(vec3(0.2126, 0.7152, 0.0722), rgb);
 }
 
-vec3 tonemap(vec3 rgb) {
-  float exponent = 1.0 / 2.2;
+float logEncodingLogC(float a) {
+  float LogC = a >= 0.01059106816664 ? 0.385537 + 0.2471896 * log10(a * 5.555556 + 0.052272) : a * 5.367655 + 0.092809;
+
+  return LogC;
+}
+
+float sigmoidK1S1(float a) {
+  float sigmoid = 1.0 / (1.0 + pow(2.718281828459045, -8.9 * (a - 0.435)));
+
+  return sigmoid;
+}
+
+vec3 viewTransformNone(vec3 rgb) {
+  return rgb;
+}
+
+vec3 viewTransformGamma22(vec3 rgb) {
+  const float exponent = 1.0 / 2.2;
+
   return pow(max(rgb, 0.0), vec3(exponent, exponent, exponent));
+}
+
+vec3 viewTransformK1S1(vec3 rgb) {
+  vec3 LogC = vec3(logEncodingLogC(rgb.x), logEncodingLogC(rgb.y), logEncodingLogC(rgb.z));
+
+  return vec3(sigmoidK1S1(LogC.x), sigmoidK1S1(LogC.y), sigmoidK1S1(LogC.z));
+}
+
+vec3 applyViewTransform(vec3 rgb, int which) {
+  if (which == ${ViewTransform.None}) {
+    return viewTransformNone(rgb);
+  } else if (which == ${ViewTransform.Gamma22}) {
+    return viewTransformGamma22(rgb);
+  } else if (which == ${ViewTransform.K1S1}) {
+    return viewTransformK1S1(rgb);
+  }
 }
 
 void main(void) {
@@ -89,8 +135,8 @@ void main(void) {
         for (int x = 0; x <= 2 * windowRadius; ++x) {
             for (int y = 0; y <= 2 * windowRadius; ++y) {
                 vec2 offset = vec2(float(x - windowRadius), float(y - windowRadius));
-                float a = luminance(tonemap(lookupOffset(imASampler, position, offset)));
-                float b = luminance(tonemap(lookupOffset(imBSampler, position, offset)));
+                float a = luminance(applyViewTransform(lookupOffset(imASampler, position, offset), viewTransform));
+                float b = luminance(applyViewTransform(lookupOffset(imBSampler, position, offset), viewTransform));
                 aSum += a; bSum += b;
                 aaSum += a * a; bbSum += b * b;
                 abSum += a * b;
@@ -114,15 +160,16 @@ void main(void) {
 
     if (mode == ${DrawMode.LDR}) {
         col = pow(col, vec3(2.2));
-        col = offset + exposure * col;
-        col = pow(col, vec3(1.0 / gamma));
+        col = pow(offset + exposure * col, vec3(1.0 / gamma));
+        col = applyViewTransform(col, viewTransform);
     } else if (mode == ${DrawMode.HDR}) {
-        col = offset + exposure * col;
-        col = pow(col, vec3(1.0 / gamma));
+        col = pow(offset + exposure * col, vec3(1.0 / gamma));
+        col = applyViewTransform(col, viewTransform);
     } else {
         float avg = (col.r + col.g + col.b) * 0.3333333333 * exposure;
         col = texture2D(cmapSampler, vec2(avg, 0.0)).rgb;
     }
+
     gl_FragColor = vec4(col, 1.0);
 }`;
 
@@ -170,6 +217,7 @@ interface WebGlUniforms {
   imASampler: WebGLUniformLocation;
   imBSampler: WebGLUniformLocation;
   cmapSampler: WebGLUniformLocation;
+  viewTransform: WebGLUniformLocation;
   exposure: WebGLUniformLocation;
   offset: WebGLUniformLocation;
   gamma: WebGLUniformLocation;
@@ -178,11 +226,12 @@ interface WebGlUniforms {
 }
 
 export interface TonemappingSettings {
+  viewTransform: number;
   offset: number;
   gamma: number;
   exposure: number;
 }
-const defaultTonemapping: TonemappingSettings = { exposure: 1.0, gamma: 2.2, offset: 0.0 };
+const defaultTonemapping: TonemappingSettings = { viewTransform:0.0, exposure: 1.0, gamma: 1.0, offset: 0.0 };
 
 export type TextureCache = (image: Image) => WebGLTexture;
 
@@ -262,6 +311,7 @@ export default class ImageLayer extends Layer {
     }
     this.gl.viewport(0, 0, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight);
 
+    this.gl.uniform1i(this.glUniforms.viewTransform, this.tonemappingSettings.viewTransform);
     this.gl.uniform1f(this.glUniforms.exposure, this.tonemappingSettings.exposure);
     this.gl.uniform1f(this.glUniforms.offset, this.tonemappingSettings.offset);
     this.gl.uniform1f(this.glUniforms.gamma, this.tonemappingSettings.gamma);
@@ -423,6 +473,7 @@ export default class ImageLayer extends Layer {
       imASampler: getUniformLocation('imASampler'),
       imBSampler: getUniformLocation('imBSampler'),
       cmapSampler: getUniformLocation('cmapSampler'),
+      viewTransform: getUniformLocation('viewTransform'),
       exposure: getUniformLocation('exposure'),
       offset: getUniformLocation('offset'),
       gamma: getUniformLocation('gamma'),

--- a/src/layers/ImageLayer.ts
+++ b/src/layers/ImageLayer.ts
@@ -58,6 +58,10 @@ float luminance(vec3 rgb) {
   return dot(vec3(0.2126, 0.7152, 0.0722), rgb);
 }
 
+vec3 GOG(vec3 rgb, float gain, float offset, float gamma) {
+  return pow(gain * rgb + offset, vec3(1.0 / gamma));
+}
+
 float logEncodingLogC(float a) {
   float LogC = a >= 0.01059106816664 ? 0.385537 + 0.2471896 * log10(a * 5.555556 + 0.052272) : a * 5.367655 + 0.092809;
 
@@ -160,10 +164,10 @@ void main(void) {
 
     if (mode == ${DrawMode.LDR}) {
         col = pow(col, vec3(2.2));
-        col = pow(offset + exposure * col, vec3(1.0 / gamma));
+        col = GOG(col, exposure, offset, gamma);
         col = applyViewTransform(col, viewTransform);
     } else if (mode == ${DrawMode.HDR}) {
-        col = pow(offset + exposure * col, vec3(1.0 / gamma));
+        col = GOG(col, exposure, offset, gamma);
         col = applyViewTransform(col, viewTransform);
     } else {
         float avg = (col.r + col.g + col.b) * 0.3333333333 * exposure;


### PR DESCRIPTION
This PR implements support for toggling between the original Gamma 2.2 view transform (encoding function) and a Pseudo ARRI K1S1 view transform. @nick-shaw and I picked K1S1 because it is a view transform that is used heavily in the VFX industry but it could be changed to something else, e.g. ACES, Hable, etc... I can implement many other but this will complexify the interactions and is probably worth discussing if it is something desired.

*Gamma 2.2*
![image](https://user-images.githubusercontent.com/99779/42681517-05948fa2-86dc-11e8-8d51-ea594fde711a.png)

*Pseudo ARRI K1S1*
![image](https://user-images.githubusercontent.com/99779/42681542-1def506e-86dc-11e8-93f7-9b7e51a72ac6.png)

The toggle is currently bound to the `t` key but can be changed to whatever key obviously.

Here are a few notes:

- We are looking at using Jeri to showcase examples on an upcoming publication hence this PR to fit our needs. 
- The `gamma` attribute is now part of a grading function and has been set to `1.0` everywhere.
- I noticed that the `exposure` parameter is not performing exposure adjustment but gain, exposure is computed as follows: `a * pow(2, EV)` where `a` is your array and `EV` the exposure compensation factor. So either it should be renamed to `gain` or changed to perform proper exposure adjustment. I can do both as a new commit in this PR.
